### PR TITLE
Add terraform-taint pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ To use:
 1. Modify the job for the given environment, TF repo and TF resource(s):
     1. In the appropriate file under `ci/terraform-taint/jobs`,
     1. modify resource reference in `get` step;
+    1. modify `TF_WORKSPACE` value;
     1. put space-separated list of TF resources into `RESOURCE_NAMES` variable
 1. Aviator and run, verify that `state show` output lists the expected resources.
 1. Uncomment the line with `taint` command.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ To use:
 1. Modify the job for the given environment, TF repo and TF resource(s):
     1. In the appropriate file under `ci/terraform-taint/jobs`,
     1. modify resource reference in `get` step;
+    1. modify `input_mapping` to match the resource reference above;
     1. modify `TF_WORKSPACE` value;
     1. put a space-separated list of TF resource addresses into `RESOURCE_ADDRESS_LIST` variable.
 1. Aviator and run, verify that `state show` output lists the expected resources.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ To use:
     1. In the appropriate file under `ci/terraform-taint/jobs`,
     1. modify resource reference in `get` step;
     1. modify `TF_WORKSPACE` value;
-    1. put space-separated list of TF resources into `RESOURCE_NAMES` variable
+    1. put a space-separated list of TF resource addresses into `RESOURCE_ADDRESS_LIST` variable
 1. Aviator and run, verify that `state show` output lists the expected resources.
 1. Uncomment the line with `taint` command.
 1. Aviator and run.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,18 @@ You can also pause or unpause the pipeline:
 
 * `make pause-ami-cleanup-pipeline`
 * `make unpause-ami-cleanup-pipeline`
+
+### Pipeline: terraform-taint
+
+A utility to taint Terraform resources. Considering the danger the jobs are disabled in the code by commenting out the `taint` command. `state show` command that precedes it allows you to test the resource address.
+
+To use:
+1. Add the Terraform repo that contains TF resource to be tainted as a Concourse resource in `ci/terraform-taint/resources-terraform-taint`
+1. Modify the job for the given environment, TF repo and TF resource(s):
+    1. In the appropriate file under `ci/terraform-taint/jobs`,
+    1. modify resource reference in `get` step;
+    1. put space-separated list of TF resources into `RESOURCE_NAMES` variable
+1. Aviator and run, verify that `state show` output lists the expected resources.
+1. Uncomment the line with `taint` command.
+1. Aviator and run.
+1. When done, reset to HEAD of master branch and aviator in so that `taint` command is commented out in Concourse 

--- a/README.md
+++ b/README.md
@@ -135,16 +135,16 @@ You can also pause or unpause the pipeline:
 
 ### Pipeline: terraform-taint
 
-A utility to taint Terraform resources. Considering the danger the jobs are disabled in the code by commenting out the `taint` command. `state show` command that precedes it allows you to test the resource address.
+A utility to taint Terraform resources. Considering the danger the jobs are disabled in the code by commenting out the `taint` command. The `state show` command that precedes it allows you to test the resource address.
 
 To use:
-1. Add the Terraform repo that contains TF resource to be tainted as a Concourse resource in `ci/terraform-taint/resources-terraform-taint`
+1. Add the Terraform repo that contains TF resource to be tainted as a Concourse resource in `ci/terraform-taint/resources-terraform-taint`.
 1. Modify the job for the given environment, TF repo and TF resource(s):
     1. In the appropriate file under `ci/terraform-taint/jobs`,
     1. modify resource reference in `get` step;
     1. modify `TF_WORKSPACE` value;
-    1. put a space-separated list of TF resource addresses into `RESOURCE_ADDRESS_LIST` variable
+    1. put a space-separated list of TF resource addresses into `RESOURCE_ADDRESS_LIST` variable.
 1. Aviator and run, verify that `state show` output lists the expected resources.
 1. Uncomment the line with `taint` command.
 1. Aviator and run.
-1. When done, reset to HEAD of master branch and aviator in so that `taint` command is commented out in Concourse 
+1. When done, reset to HEAD of master branch and aviator in so that `taint` command is commented out in Concourse.

--- a/aviator-terraform-taint.yml
+++ b/aviator-terraform-taint.yml
@@ -1,0 +1,17 @@
+spruce:
+- base: ci/terraform-taint/meta-terraform-taint.yml
+  prune:
+    - meta
+  merge:
+    - with_in: ci/terraform-taint/
+      regexp: ".*yml"
+    - with_in: ci/terraform-taint/jobs/
+      regexp: ".*yml"
+    - with_in: ci/shared/
+      regexp: "meta.yml"
+  to: aviator_pipeline_terraform-taint.yml
+fly:
+  name: terraform-taint
+  target: concourse
+  config: aviator_pipeline_terraform-taint.yml
+  expose: false

--- a/ci/terraform-taint/jobs/dev-taint.yml
+++ b/ci/terraform-taint/jobs/dev-taint.yml
@@ -1,0 +1,24 @@
+jobs:
+  - name: development-terraform-taint
+    max_in_flight: 1
+    plan:
+      - get: aws-ingestion
+        trigger: false
+      - get: aws-sdx
+        trigger: false
+      - .: (( inject meta.plan.create-aws-profiles ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.development))
+      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+        input_mapping:
+          tfrepo: aws-ingestion
+        config:
+          params:
+            RESOURCE_NAMES: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
+      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+        input_mapping:
+          tfrepo: aws-sdx
+        config:
+          params:
+            RESOURCE_NAMES: "aws_ecs_service.stub_nifi[0]"

--- a/ci/terraform-taint/jobs/dev-taint.yml
+++ b/ci/terraform-taint/jobs/dev-taint.yml
@@ -16,11 +16,11 @@ jobs:
         config:
           params:
             TF_WORKSPACE: 'default'
-            RESOURCE_NAMES: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
+            RESOURCE_ADDRESS_LIST: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
       - .: (( inject meta-terraform-taint.plan.terraform-taint ))
         input_mapping:
           tfrepo: aws-sdx
         config:
           params:
             TF_WORKSPACE: 'default'
-            RESOURCE_NAMES: "aws_ecs_service.stub_nifi[0]"
+            RESOURCE_ADDRESS_LIST: "aws_ecs_service.stub_nifi[0]"

--- a/ci/terraform-taint/jobs/dev-taint.yml
+++ b/ci/terraform-taint/jobs/dev-taint.yml
@@ -2,25 +2,28 @@ jobs:
   - name: development-terraform-taint
     max_in_flight: 1
     plan:
-      - get: aws-ingestion
-        trigger: false
-      - get: aws-sdx
-        trigger: false
+      - aggregate:
+        - get: aws-ingestion
+          trigger: false
+        - get: aws-sdx
+          trigger: false
       - .: (( inject meta.plan.create-aws-profiles ))
         config:
           params:
             AWS_ACC: ((aws_account.development))
-      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
-        input_mapping:
-          tfrepo: aws-ingestion
-        config:
-          params:
-            TF_WORKSPACE: 'default'
-            RESOURCE_ADDRESS_LIST: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
-      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
-        input_mapping:
-          tfrepo: aws-sdx
-        config:
-          params:
-            TF_WORKSPACE: 'default'
-            RESOURCE_ADDRESS_LIST: "aws_ecs_service.stub_nifi[0]"
+      - aggregate:
+        - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+          input_mapping:
+            tfrepo: aws-ingestion
+          config:
+            params:
+              TF_WORKSPACE: 'default'
+              RESOURCE_ADDRESS_LIST: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
+        - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+          input_mapping:
+            tfrepo: aws-sdx
+          config:
+            params:
+              TF_WORKSPACE: 'default'
+              RESOURCE_ADDRESS_LIST: "aws_ecs_service.stub_nifi[0]"
+

--- a/ci/terraform-taint/jobs/dev-taint.yml
+++ b/ci/terraform-taint/jobs/dev-taint.yml
@@ -15,10 +15,12 @@ jobs:
           tfrepo: aws-ingestion
         config:
           params:
+            TF_WORKSPACE: 'default'
             RESOURCE_NAMES: "aws_ecs_service.kafka_to_hbase_consumer[0] aws_ecs_service.stub_ucfs_kafka_to_s3[0]"
       - .: (( inject meta-terraform-taint.plan.terraform-taint ))
         input_mapping:
           tfrepo: aws-sdx
         config:
           params:
+            TF_WORKSPACE: 'default'
             RESOURCE_NAMES: "aws_ecs_service.stub_nifi[0]"

--- a/ci/terraform-taint/jobs/mgmtdev-taint.yml
+++ b/ci/terraform-taint/jobs/mgmtdev-taint.yml
@@ -2,16 +2,18 @@ jobs:
   - name: management-dev-terraform-taint
     max_in_flight: 1
     plan:
-      - get: aws-internet-egress
-        trigger: false
+      - aggregate:
+        - get: aws-internet-egress
+          trigger: false
       - .: (( inject meta.plan.create-aws-profiles ))
         config:
           params:
             AWS_ACC: ((aws_account.management-dev))
-      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
-        input_mapping:
-          tfrepo: aws-internet-egress
-        config:
-          params:
-            TF_WORKSPACE: 'default'
-            RESOURCE_ADDRESS_LIST: "aws_ecs_service.container_internet_proxy"
+      - aggregate:
+        - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+          input_mapping:
+            tfrepo: aws-internet-egress
+          config:
+            params:
+              TF_WORKSPACE: 'default'
+              RESOURCE_ADDRESS_LIST: "aws_ecs_service.container_internet_proxy"

--- a/ci/terraform-taint/jobs/mgmtdev-taint.yml
+++ b/ci/terraform-taint/jobs/mgmtdev-taint.yml
@@ -1,0 +1,16 @@
+jobs:
+  - name: management-dev-terraform-taint
+    max_in_flight: 1
+    plan:
+      - get: aws-internet-egress
+        trigger: false
+      - .: (( inject meta.plan.create-aws-profiles ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.management-dev))
+      - .: (( inject meta-terraform-taint.plan.terraform-taint ))
+        input_mapping:
+          tfrepo: aws-internet-egress
+        config:
+          params:
+            RESOURCE_NAMES: "aws_ecs_service.container_internet_proxy"

--- a/ci/terraform-taint/jobs/mgmtdev-taint.yml
+++ b/ci/terraform-taint/jobs/mgmtdev-taint.yml
@@ -13,4 +13,5 @@ jobs:
           tfrepo: aws-internet-egress
         config:
           params:
+            TF_WORKSPACE: 'default'
             RESOURCE_NAMES: "aws_ecs_service.container_internet_proxy"

--- a/ci/terraform-taint/jobs/mgmtdev-taint.yml
+++ b/ci/terraform-taint/jobs/mgmtdev-taint.yml
@@ -14,4 +14,4 @@ jobs:
         config:
           params:
             TF_WORKSPACE: 'default'
-            RESOURCE_NAMES: "aws_ecs_service.container_internet_proxy"
+            RESOURCE_ADDRESS_LIST: "aws_ecs_service.container_internet_proxy"

--- a/ci/terraform-taint/meta-terraform-taint.yml
+++ b/ci/terraform-taint/meta-terraform-taint.yml
@@ -1,0 +1,37 @@
+meta-terraform-taint:
+  plan:
+    terraform-taint:
+      task: terraform-taint
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((terraform.repository))
+            version: ((terraform12.version))
+            tag: ((terraform12.version))
+        inputs:
+          - name: tfrepo
+        params:
+          TF_CLI_ARGS_plan: -lock-timeout=300s
+          TF_INPUT: "false"
+          TF_VAR_slack_webhook_url: ((slack.webhook_url))
+          AWS_ACCESS_KEY_ID: ((ci.aws_access_key_id))
+          AWS_SECRET_ACCESS_KEY: ((ci.aws_secret_access_key))
+          RESOURCE_NAMES: "unset unset"
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd tfrepo
+              terraform workspace show
+              terraform init
+              for NAME in ${RESOURCE_NAMES}; do
+                #
+                #  This is dangerous. Taint command should always be commented out in the repo.
+                #  To use, uncomment and aviator in. Remember to aviator in the commented out version back after.
+                #
+                terraform state show ${NAME}
+                # terraform taint ${NAME}
+              done

--- a/ci/terraform-taint/meta-terraform-taint.yml
+++ b/ci/terraform-taint/meta-terraform-taint.yml
@@ -18,7 +18,7 @@ meta-terraform-taint:
           TF_VAR_slack_webhook_url: ((slack.webhook_url))
           AWS_ACCESS_KEY_ID: ((ci.aws_access_key_id))
           AWS_SECRET_ACCESS_KEY: ((ci.aws_secret_access_key))
-          RESOURCE_NAMES: "unset unset"
+          RESOURCE_ADDRESS_LIST: "unset unset"
         run:
           path: sh
           dir: tfrepo
@@ -27,11 +27,11 @@ meta-terraform-taint:
             - |
               terraform workspace show
               terraform init
-              for NAME in ${RESOURCE_NAMES}; do
+              for RESOURCE_ADDRESS in ${RESOURCE_ADDRESS_LIST}; do
                 #
                 #  This is dangerous. Taint command should always be commented out in the repo.
                 #  To use, uncomment and aviator in. Remember to aviator in the commented out version back after.
                 #
-                terraform state show ${NAME}
-                # terraform taint ${NAME}
+                terraform state show ${RESOURCE_ADDRESS}
+                # terraform taint ${RESOURCE_ADDRESS}
               done

--- a/ci/terraform-taint/meta-terraform-taint.yml
+++ b/ci/terraform-taint/meta-terraform-taint.yml
@@ -15,13 +15,12 @@ meta-terraform-taint:
         params:
           TF_CLI_ARGS_plan: -lock-timeout=300s
           TF_INPUT: "false"
-          TF_VAR_slack_webhook_url: ((slack.webhook_url))
           AWS_ACCESS_KEY_ID: ((ci.aws_access_key_id))
           AWS_SECRET_ACCESS_KEY: ((ci.aws_secret_access_key))
           RESOURCE_ADDRESS_LIST: "unset unset"
         run:
-          path: sh
           dir: tfrepo
+          path: sh
           args:
             - -exc
             - |

--- a/ci/terraform-taint/meta-terraform-taint.yml
+++ b/ci/terraform-taint/meta-terraform-taint.yml
@@ -2,6 +2,7 @@ meta-terraform-taint:
   plan:
     terraform-taint:
       task: terraform-taint
+      attempts: 3
       config:
         platform: linux
         image_resource:

--- a/ci/terraform-taint/meta-terraform-taint.yml
+++ b/ci/terraform-taint/meta-terraform-taint.yml
@@ -21,10 +21,10 @@ meta-terraform-taint:
           RESOURCE_NAMES: "unset unset"
         run:
           path: sh
+          dir: tfrepo
           args:
             - -exc
             - |
-              cd tfrepo
               terraform workspace show
               terraform init
               for NAME in ${RESOURCE_NAMES}; do

--- a/ci/terraform-taint/resources-terraform-taint.yml
+++ b/ci/terraform-taint/resources-terraform-taint.yml
@@ -5,7 +5,7 @@ resources:
       branch: master
       private_key: ((svc-dip.private_key))
       uri: git@github.ucds.io:dip/aws-ingestion.git
-    check_every: 720h
+    check_every: 15m
     webhook_token: ((ucfs-github.webhook-token))
 
   - name: aws-sdx
@@ -14,7 +14,7 @@ resources:
       branch: master
       private_key: ((svc-dip.private_key))
       uri: git@github.ucds.io:dip/aws-sdx.git
-    check_every: 720h
+    check_every: 15m
     webhook_token: ((ucfs-github.webhook-token))
 
   - name: aws-internet-egress
@@ -23,5 +23,5 @@ resources:
       branch: master
       private_key: ((svc-dip.private_key))
       uri: git@github.ucds.io:dip/aws-internet-egress.git
-    check_every: 720h
+    check_every: 15m
     webhook_token: ((ucfs-github.webhook-token))

--- a/ci/terraform-taint/resources-terraform-taint.yml
+++ b/ci/terraform-taint/resources-terraform-taint.yml
@@ -1,0 +1,27 @@
+resources:
+  - name: aws-ingestion
+    type: git
+    source:
+      branch: master
+      private_key: ((svc-dip.private_key))
+      uri: git@github.ucds.io:dip/aws-ingestion.git
+    check_every: 720h
+    webhook_token: ((ucfs-github.webhook-token))
+
+  - name: aws-sdx
+    type: git
+    source:
+      branch: master
+      private_key: ((svc-dip.private_key))
+      uri: git@github.ucds.io:dip/aws-sdx.git
+    check_every: 720h
+    webhook_token: ((ucfs-github.webhook-token))
+
+  - name: aws-internet-egress
+    type: git
+    source:
+      branch: master
+      private_key: ((svc-dip.private_key))
+      uri: git@github.ucds.io:dip/aws-internet-egress.git
+    check_every: 720h
+    webhook_token: ((ucfs-github.webhook-token))


### PR DESCRIPTION
A utility to taint Terraform resources.
Dangerous stuff is commented out and should stay like that in `master`

See DW-4129