### PR TITLE
The UC Data Load jobs for lower environments did not have the require…

### DIFF
--- a/ci/uc-data-load/jobs/development.yml
+++ b/ci/uc-data-load/jobs/development.yml
@@ -24,3 +24,4 @@ jobs:
     config:
       params:
         AWS_ACC: ((aws_account.development))
+        ACTION_TAG: '@admin-uc-data-load'

--- a/ci/uc-data-load/jobs/preprod.yml
+++ b/ci/uc-data-load/jobs/preprod.yml
@@ -34,3 +34,4 @@ jobs:
     config:
       params:
         AWS_ACC: ((aws_account.preprod))
+        ACTION_TAG: '@admin-uc-data-load'

--- a/ci/uc-data-load/jobs/qa.yml
+++ b/ci/uc-data-load/jobs/qa.yml
@@ -30,3 +30,4 @@ jobs:
     config:
       params:
         AWS_ACC: ((aws_account.qa))
+        ACTION_TAG: '@admin-uc-data-load'


### PR DESCRIPTION
The UC Data Load jobs for lower environments did not have the required tag to actually run the right admin job