### PR TITLE
Changes the snapshot jobs to always use the poller functionality now …

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To use:
  The below describe the purpose of the flags used in generate snapshots pipelines.
  These configurations are by default set to false , However they can set to true when needed and aviator the changes 
  to take effect in concourse.
- 1. GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE - True to trigger ADG post HTME completion
+ 1. GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE - True to trigger ADG post HTME completion
  2. GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE - True to trigger snapshot sender along with HTME
  3. GENERATE_SNAPSHOTS_REPROCESS_FILES_OVERRIDE - True to overwrite existing files of snapshot sender
  4. GENERATE_SNAPSHOTS_TOPICS_OVERRIDE - config to override with topic names to be processed by HTME and snapshot sender

--- a/ci/generate-snapshots/jobs/development-generate-full-snapshots.yml
+++ b/ci/generate-snapshots/jobs/development-generate-full-snapshots.yml
@@ -25,5 +25,7 @@ jobs:
           params:
             AWS_ACC: ((aws_account.development))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots-with-completion-status-poller
-            GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE: false
+            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/development-generate-incremental-snapshots.yml
+++ b/ci/generate-snapshots/jobs/development-generate-incremental-snapshots.yml
@@ -26,3 +26,6 @@ jobs:
             AWS_ACC: ((aws_account.development))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             E2E_FEATURE_TAG_FILTER: admin-generate-incremental-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/integration-generate-full-snapshots.yml
+++ b/ci/generate-snapshots/jobs/integration-generate-full-snapshots.yml
@@ -33,7 +33,7 @@ jobs:
           params:
             AWS_ACC: ((aws_account.integration))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots-with-completion-status-poller
-            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "db.matchingService.managementInformation,db.core.contract,db.accepted-data.address,db.agent-core.agent,db.agent-core.agentToDo,db.agent-core.team,db.core.claimant"
+            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
             GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
-            GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/integration-generate-incremental-snapshots.1.yml
+++ b/ci/generate-snapshots/jobs/integration-generate-incremental-snapshots.1.yml
@@ -36,3 +36,4 @@ jobs:
             E2E_FEATURE_TAG_FILTER: admin-generate-incremental-snapshots
             GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
             GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/preprod-generate-full-snapshots.yml
+++ b/ci/generate-snapshots/jobs/preprod-generate-full-snapshots.yml
@@ -33,8 +33,7 @@ jobs:
           params:
             AWS_ACC: ((aws_account.preprod))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots-with-completion-status-poller
-            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "db.work-search-core.job"
+            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
             GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
-            GENERATE_SNAPSHOTS_REPROCESS_FILES_OVERRIDE: false
-            GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/preprod-generate-incremental-snapshots.yml
+++ b/ci/generate-snapshots/jobs/preprod-generate-incremental-snapshots.yml
@@ -34,3 +34,6 @@ jobs:
             AWS_ACC: ((aws_account.preprod))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
             E2E_FEATURE_TAG_FILTER: admin-generate-incremental-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/production-generate-full-snapshots.yml
+++ b/ci/generate-snapshots/jobs/production-generate-full-snapshots.yml
@@ -36,8 +36,7 @@ jobs:
           params:
             AWS_ACC: ((aws_account.production))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots-with-completion-status-poller
+            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots
             GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
             GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
-            GENERATE_SNAPSHOTS_REPROCESS_FILES_OVERRIDE: false
-            GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/production-generate-incremental-snapshots.yml
+++ b/ci/generate-snapshots/jobs/production-generate-incremental-snapshots.yml
@@ -35,5 +35,5 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             E2E_FEATURE_TAG_FILTER: admin-generate-incremental-snapshots
             GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
-            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: true
-            GENERATE_SNAPSHOTS_REPROCESS_FILES_OVERRIDE: true
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/qa-generate-full-snapshots.yml
+++ b/ci/generate-snapshots/jobs/qa-generate-full-snapshots.yml
@@ -33,5 +33,7 @@ jobs:
           params:
             AWS_ACC: ((aws_account.qa))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots-with-completion-status-poller
-            GENERATE_SNAPSHOTS_TRIGGER_ADG_OVERRIDE: false
+            E2E_FEATURE_TAG_FILTER: admin-generate-full-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false

--- a/ci/generate-snapshots/jobs/qa-generate-incremental-snapshots.yml
+++ b/ci/generate-snapshots/jobs/qa-generate-incremental-snapshots.yml
@@ -34,3 +34,6 @@ jobs:
             AWS_ACC: ((aws_account.qa))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
             E2E_FEATURE_TAG_FILTER: admin-generate-incremental-snapshots
+            GENERATE_SNAPSHOTS_TOPICS_OVERRIDE: "ALL"
+            GENERATE_SNAPSHOTS_TRIGGER_SNAPSHOT_SENDER_OVERRIDE: false
+            GENERATE_SNAPSHOTS_USE_POLLER_OVERRIDE: false


### PR DESCRIPTION
Changes the snapshot jobs to always use the poller functionality now that it is supported by both full and incremental snapshots for ingest hbase pipeline but not for mani pipeline unless explicitly overridden