### PR TITLE
Changes to the "Taint" job for analytical environment

### DIFF
--- a/ci/analytical-env-admin/jobs/taint/dev.yml
+++ b/ci/analytical-env-admin/jobs/taint/dev.yml
@@ -17,9 +17,10 @@ jobs:
         params:
           DEPLOY_PATH: app
 
-      - .: (( inject meta-analytical-env-admin.plan.terraform-taint ))
+      - .: (( inject meta-analytical-env-admin.plan.aws-destroy-emr-cluster ))
         params:
-          DEPLOY_PATH: app
+          CLUSTER_NAME: aws-analytical-env
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-apply ))
         config:
@@ -29,9 +30,10 @@ jobs:
             - name: emr-launcher-release
             - name: manage-mysql-user-release
             - name: hive-custom-auth-release
+        attempts: 3
         params:
           DEPLOY_PATH: app
-        
+
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-plan ))
         config:

--- a/ci/analytical-env-admin/jobs/taint/int.yml
+++ b/ci/analytical-env-admin/jobs/taint/int.yml
@@ -18,10 +18,10 @@ jobs:
         params:
           DEPLOY_PATH: app
 
-      - .: (( inject meta-analytical-env-admin.plan.terraform-taint ))
+      - .: (( inject meta-analytical-env-admin.plan.aws-destroy-emr-cluster ))
         params:
-          DEPLOY_PATH: app
-          TF_WORKSPACE: 'integration'
+          CLUSTER_NAME: aws-analytical-env
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-apply ))
         config:
@@ -31,6 +31,7 @@ jobs:
             - name: emr-launcher-release
             - name: manage-mysql-user-release
             - name: hive-custom-auth-release
+        attempts: 3
         params:
           DEPLOY_PATH: app
           TF_WORKSPACE: 'integration'

--- a/ci/analytical-env-admin/jobs/taint/preprod.yml
+++ b/ci/analytical-env-admin/jobs/taint/preprod.yml
@@ -18,10 +18,10 @@ jobs:
         params:
           DEPLOY_PATH: app
 
-      - .: (( inject meta-analytical-env-admin.plan.terraform-taint ))
+      - .: (( inject meta-analytical-env-admin.plan.aws-destroy-emr-cluster ))
         params:
-          DEPLOY_PATH: app
-          TF_WORKSPACE: 'preprod'
+          CLUSTER_NAME: aws-analytical-env
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-apply ))
         config:
@@ -31,6 +31,7 @@ jobs:
             - name: emr-launcher-release
             - name: manage-mysql-user-release
             - name: hive-custom-auth-release
+        attempts: 3
         params:
           DEPLOY_PATH: app
           TF_WORKSPACE: 'preprod'

--- a/ci/analytical-env-admin/jobs/taint/prod.yml
+++ b/ci/analytical-env-admin/jobs/taint/prod.yml
@@ -18,10 +18,10 @@ jobs:
         params:
           DEPLOY_PATH: app
 
-      - .: (( inject meta-analytical-env-admin.plan.terraform-taint ))
+      - .: (( inject meta-analytical-env-admin.plan.aws-destroy-emr-cluster ))
         params:
-          DEPLOY_PATH: app
-          TF_WORKSPACE: 'production'
+          CLUSTER_NAME: aws-analytical-env
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-apply ))
         config:
@@ -31,6 +31,7 @@ jobs:
             - name: emr-launcher-release
             - name: manage-mysql-user-release
             - name: hive-custom-auth-release
+        attempts: 3
         params:
           DEPLOY_PATH: app
           TF_WORKSPACE: 'production'

--- a/ci/analytical-env-admin/jobs/taint/qa.yml
+++ b/ci/analytical-env-admin/jobs/taint/qa.yml
@@ -17,10 +17,10 @@ jobs:
         params:
           DEPLOY_PATH: app
 
-      - .: (( inject meta-analytical-env-admin.plan.terraform-taint ))
+      - .: (( inject meta-analytical-env-admin.plan.aws-destroy-emr-cluster ))
         params:
-          DEPLOY_PATH: app
-          TF_WORKSPACE: 'qa'
+          CLUSTER_NAME: aws-analytical-env
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
 
       - .: (( inject meta-analytical-env-admin.plan.terraform-apply ))
         config:
@@ -30,6 +30,7 @@ jobs:
             - name: emr-launcher-release
             - name: manage-mysql-user-release
             - name: hive-custom-auth-release
+        attempts: 3
         params:
           DEPLOY_PATH: app
           TF_WORKSPACE: 'qa'

--- a/ci/analytical-env-admin/meta-analytical-env-admin.yml
+++ b/ci/analytical-env-admin/meta-analytical-env-admin.yml
@@ -160,6 +160,65 @@ meta-analytical-env-admin:
           - name: aws-analytical-env
           - name: terraform-config
 
+    aws-destroy-emr-cluster:
+      task: aws-destroy-emr-cluster
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            version: ((dataworks.docker_awscli_version))
+            tag: ((dataworks.docker_awscli_version))
+        params:
+          AWS_ROLE_ARN: UNSET
+          AWS_REGION: ((dataworks.aws_region))
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+        run:
+          path: sh
+          args:
+            - -ec
+            - |
+              source /assume-role
+
+              function cluster_status {
+                local cluster_id=$1
+                aws --output json --region="$AWS_REGION" \
+                  emr describe-cluster --cluster-id $cluster_id | jq -r '.Cluster.Status.State'
+              }
+
+              cluster_id=$(aws --output json --region="$AWS_REGION" \
+                                emr list-clusters --active --query "Clusters[?Name=='$CLUSTER_NAME'].[Id][0][0]" | tr -d '"')
+
+              if [[ $cluster_id != "null" ]]; then
+                echo destroying: $CLUSTER_NAME - $cluster_id
+                # Terminate using AWS CLI because targetted destroys can cause
+                # issues with TF (orphaned resources, etc.)
+                aws --region="$AWS_REGION" emr terminate-clusters --cluster-ids $cluster_id
+
+                i=0
+                while [[ $i -le 360 ]]; do
+                  status=$(cluster_status $cluster_id)
+                  if [ "$status" == "TERMINATED" ]; then
+                    echo status: \'$status\', cluster terminated exiting normally.
+                    exit 0
+                  fi
+
+                  if [ "$status" == "TERMINATED_WITH_ERRORS" ]; then
+                    echo status: \'$status\', cluster terminated with errors exiting normally.
+                    exit 0
+                  fi
+
+                  i=$((i+1))
+                  echo status: \'$status\', sleeping for 10 seconds.
+                  sleep 10
+                done
+
+                echo Monitoring of the destruction has timed out, progressing anyway
+              else
+                echo No cluster with name: $CLUSTER_NAME exists, therefore not destroying. Continuing...
+              fi
+
     rotate-mysql-master-password:
       task: rotate-mysql-master-password
       config:


### PR DESCRIPTION
- add `attempts: 3` to deployment, accounting for any issues with IP allocation
- destroy emr manually via cli (similar to ingest-hbase) before deployment